### PR TITLE
Pass previous exception in event store conflicts resolver logger.

### DIFF
--- a/src/Broadway/EventStore/ConcurrencyConflictResolvingEventStore.php
+++ b/src/Broadway/EventStore/ConcurrencyConflictResolvingEventStore.php
@@ -71,7 +71,7 @@ final class ConcurrencyConflictResolvingEventStore implements EventStore
                     return $domainMessage->getId().': '.$domainMessage->getType();
                 }, iterator_to_array($uncommittedEvents));
 
-                throw new \Exception('Error on concurrency conflicting resolve event store. '.implode(' - ', $loggedEvents));
+                throw new \Exception('Error on concurrency conflicting resolve event store. '.implode(' - ', $loggedEvents), 0, $e);
             }
         }
     }


### PR DESCRIPTION
Actually if the append method inside the first catch fails, we can't know the reason and we can't easily recgnize that retries are all failed.